### PR TITLE
Fixed bug

### DIFF
--- a/mt.c
+++ b/mt.c
@@ -838,6 +838,8 @@ void color_print(int f_index, NEWWIN *win, proginfo *cur, char *string, regmatch
 		 * the stripping part should be moved to a seperate function
 		 */
 		cdev = choose_color(string, cur, &cmatches, &n_cmatches, &has_merge_colors, &use_string);
+    
+    memcpy(string, use_string, strlen(use_string)+1);
 
 		/* if not using colorschemes (which can have more then one color
 		 * per line), set the color


### PR DESCRIPTION
The function `choose_color` strips the provided string of any color codes it may have. This function is run to populate the buffer during the initialisation of the program. However, the result of the function is stored in `use_string` and not in the `string` variable. `string` is instead mutated during the stripping process, and this was earlier being used to populate the buffer. The solution simply copies the value of `use_string` to `string` to initialise the buffer correctly.