### PR TITLE
multitail: always use "%s"-style format for printf()-style functions

### DIFF
--- a/mt.c
+++ b/mt.c
@@ -1459,14 +1459,8 @@ void update_statusline(NEWWIN *status, int win_nr, proginfo *cur)
 				else
 				{
 					cur_len = 13;
-					/* is this trick still neccessary as I moved from off_t to off64_t? */
-#if 0
-					/* this trick is because on MacOS X 'off_t' is specified as a 64 bit integer */
-#endif
-					if (sizeof(off64_t) == 8)
-						mvwprintw(status -> win, 0, win_width - (strlen(timestamp) + cur_len), "%10lld - %s", fsize, timestamp);
-					else
-						mvwprintw(status -> win, 0, win_width - (strlen(timestamp) + cur_len), "%10ld - %s", fsize, timestamp);
+					/* Accomodate for both 32-bit and 64-bit off_t. */
+					mvwprintw(status -> win, 0, win_width - (strlen(timestamp) + cur_len), "%10lld - %s", (long long)fsize, timestamp);
 				}
 
 				total_info_len = statusline_len + cur_len;
@@ -1743,7 +1737,7 @@ void create_windows(void)
 		menu_win = mynewwin(max_y, max_x, 0, 0);
 		werase(menu_win -> win);
 
-		wprintw(menu_win -> win, version_str);
+		wprintw(menu_win -> win, "%s", version_str);
 		wprintw(menu_win -> win, "\n\n");
 
 		wprintw(menu_win -> win, "%s\n", F1);

--- a/stripstring.c
+++ b/stripstring.c
@@ -154,7 +154,7 @@ int edit_strippers(void)
 		memset(linebuf, ' ', sizeof(linebuf) - 1);
 		linebuf[sizeof(linebuf) - 1] = 0x00;
 		for(loop=4; loop<22; loop++)
-			mvwprintw(mywin -> win, loop, 1, linebuf);
+			mvwprintw(mywin -> win, loop, 1, "%s", linebuf);
 
 		/* display them lines */
 		for(loop=0; loop<cur -> n_strip; loop++)

--- a/term.c
+++ b/term.c
@@ -159,7 +159,7 @@ char * edit_string(NEWWIN *win, int win_y, int win_x, int win_width, int max_wid
 		string[copy_len] = 0x00;
 
 		str_pos = dummy;
-		mvwprintw(win -> win, win_y, win_x, &string[dummy]);
+		mvwprintw(win -> win, win_y, win_x, "%s", &string[dummy]);
 		x = strlen(string) - dummy;
 	}
 	else
@@ -608,7 +608,7 @@ void escape_print(NEWWIN *win, int y, int x, char *str)
 void win_header(NEWWIN *win, char *str)
 {
 	wattron(win -> win, A_BOLD);
-	mvwprintw(win -> win, 1, 2, str);
+	mvwprintw(win -> win, 1, 2, "%s", str);
 	wattroff(win -> win, A_BOLD);
 }
 

--- a/ui.c
+++ b/ui.c
@@ -1085,7 +1085,7 @@ int toggle_colors(void)
 
 			dummy = mystrdup(cur -> filename);
 			dummy[min(strlen(dummy), 40)] = 0x00;
-			mvwprintw(mywin -> win, 3, 1, dummy);
+			mvwprintw(mywin -> win, 3, 1, "%s", dummy);
 
 			col = ask_colors(mywin, 4, cur -> cdef.colorize, &cur -> cdef.field_nr, &cur -> cdef.field_del, &cur -> cdef.color_schemes, &cur -> cdef.attributes, &cur -> cdef.term_emul);
 			if (col != (char)-1)
@@ -1164,7 +1164,7 @@ int edit_regexp(void)
 				char dummy[18];
 				strncpy(dummy, (cur -> pre)[loop].cmd, min(17, strlen((cur -> pre)[loop].cmd)));
 				dummy[17]=0x00;
-				mvwprintw(mywin -> win, 4 + loop, 42, dummy);
+				mvwprintw(mywin -> win, 4 + loop, 42, "%s", dummy);
 				wmove(mywin -> win, 4 + loop, 41);
 			}
 			if (loop == cur_re)


### PR DESCRIPTION
`ncuses-6.3` added printf-style function attributes and now makes
it easier to catch cases when user input is used in palce of format
string when built with CFLAGS=-Werror=format-security:

    ui.c:1167:71: error: format not a string literal and no format arguments [-Werror=format-security]
     1167 |                                 mvwprintw(mywin -> win, 4 + loop, 42, dummy);
          |                                                                       ^~~~~

Let's wrap all the missing places with "%s" format.